### PR TITLE
feat: add cluster deletion endpoint

### DIFF
--- a/gateway/handler/cluster.go
+++ b/gateway/handler/cluster.go
@@ -2,6 +2,8 @@ package handler
 
 import (
 	"context"
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/koor-tech/genesis/gateway/request"
@@ -9,7 +11,6 @@ import (
 	"github.com/koor-tech/genesis/pkg/database"
 	"github.com/koor-tech/genesis/pkg/models"
 	"github.com/koor-tech/genesis/pkg/rabbitmq"
-	"net/http"
 )
 
 var (
@@ -35,7 +36,7 @@ func CreateCluster(c *gin.Context) {
 		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err})
 		return
 	}
-	c.JSON(201, gin.H{"cluster": clusterState})
+	c.JSON(http.StatusCreated, gin.H{"cluster": clusterState})
 }
 
 func GetCluster(c *gin.Context) {
@@ -46,5 +47,15 @@ func GetCluster(c *gin.Context) {
 		c.AbortWithStatusJSON(http.StatusNotFound, gin.H{"error": err})
 		return
 	}
-	c.JSON(201, gin.H{"cluster": koorCluster})
+	c.JSON(http.StatusCreated, gin.H{"cluster": koorCluster})
+}
+
+func DeleteCluster(c *gin.Context) {
+	clusterID := uuid.MustParse(c.Param("id"))
+	clusterSvc := cluster.NewService(database.NewDB(), rabbitmq.NewClient())
+	if err := clusterSvc.DeleteCluster(context.Background(), clusterID); err != nil {
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"cluster": nil})
 }

--- a/gateway/handler/status.go
+++ b/gateway/handler/status.go
@@ -1,9 +1,13 @@
 package handler
 
-import "github.com/gin-gonic/gin"
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
 
 func GetStatus(c *gin.Context) {
-	c.JSON(200, gin.H{
+	c.JSON(http.StatusOK, gin.H{
 		"status": "ok",
 	})
 }

--- a/gateway/router.go
+++ b/gateway/router.go
@@ -13,6 +13,7 @@ func SetupRouter() *gin.Engine {
 	{
 		v1.POST("/cluster", handler.CreateCluster)
 		v1.GET("/clusters/:id", handler.GetCluster)
+		v1.DELETE("/cluster/:id", handler.DeleteCluster)
 	}
 	return r
 }

--- a/pkg/kubeone/terraform.go
+++ b/pkg/kubeone/terraform.go
@@ -4,16 +4,17 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+
 	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/koor-tech/genesis/pkg/files"
 	"github.com/koor-tech/genesis/pkg/models"
 	"github.com/koor-tech/genesis/pkg/providers/hetzner"
 	"github.com/koor-tech/genesis/pkg/types"
 	"gopkg.in/yaml.v3"
-	"log"
-	"os"
-	"os/exec"
-	"strings"
 )
 
 type Builder struct {
@@ -54,8 +55,8 @@ func (b *Builder) WriteTFVars() error {
 
 }
 
-func (b *Builder) WriteConfigFile() error {
-	clusterConfig := models.NewKubeOneConfig()
+func (b *Builder) WriteConfigFile(clusterName string) error {
+	clusterConfig := models.NewKubeOneConfig(clusterName)
 
 	configData, err := yaml.Marshal(clusterConfig)
 	if err != nil {

--- a/pkg/models/cluster_state.go
+++ b/pkg/models/cluster_state.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"encoding/json"
+
 	"github.com/google/uuid"
 )
 
@@ -22,6 +23,10 @@ const (
 	ClusterPhaseClusterReady     ClusterPhase = 100
 	ClusterPhaseInstallCephInit  ClusterPhase = 110
 	ClusterPhaseInstallCephDone  ClusterPhase = 120
+
+	// Make sure we have enough room for any other non-destructive cluster phases
+	ClusterPhaseDeletingCluster ClusterPhase = 900
+	ClusterPhaseClusterDeleted  ClusterPhase = 999
 )
 
 type ClusterState struct {

--- a/pkg/models/kubeone.go
+++ b/pkg/models/kubeone.go
@@ -15,14 +15,16 @@ type CloudProvider struct {
 type KubeOneConfig struct {
 	ApiVersion    string        `yaml:"apiVersion"`
 	Kind          string        `yaml:"kind"`
+	Name          string        `yaml:"name"`
 	Versions      Versions      `yaml:"versions"`
 	CloudProvider CloudProvider `yaml:"cloudProvider"`
 }
 
-func NewKubeOneConfig() *KubeOneConfig {
+func NewKubeOneConfig(clusterName string) *KubeOneConfig {
 	return &KubeOneConfig{
 		ApiVersion: "kubeone.k8c.io/v1beta2",
 		Kind:       "KubeOneCluster",
+		Name:       clusterName,
 		Versions: Versions{
 			Kubernetes: "1.25.6",
 		},

--- a/pkg/utils/labels.go
+++ b/pkg/utils/labels.go
@@ -1,0 +1,7 @@
+package utils
+
+import "fmt"
+
+func Label(k string, v string) string {
+	return fmt.Sprintf("%s=%s", k, v)
+}

--- a/templates/hetzner/main.tf
+++ b/templates/hetzner/main.tf
@@ -35,6 +35,10 @@ resource "hcloud_ssh_key" "kubeone" {
 resource "hcloud_network" "net" {
   name     = var.cluster_name
   ip_range = var.ip_range
+
+  labels = {
+    "kubeone_cluster_name" = var.cluster_name
+  }
 }
 
 resource "hcloud_firewall" "cluster" {


### PR DESCRIPTION
The code has not been tested yet.

A "big change" that we need to make sure to do right once is the cluster name. Currently, I'm assuming the cluster's UUID is the cluster name for the kubeone config, and therefore the cloud resource label.